### PR TITLE
extend the wait time in takeScreenshot_function

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ const takeScreenshot = async (url) => {
   const page = await browser.newPage()
   page.setViewport({ width: 1024, height: 360 })
   await page.goto(url)
-  await sleep(2000)
+  await sleep(5000)
   await page.screenshot({ path: file, fullPage: true })
   await browser.close()
   return file


### PR DESCRIPTION
I sometimes take screenshots while the page is loading, so I want to extend the wait time.