### PR TITLE
Fixed Error RUN apt-get install -y fonts-noto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/playwright:bionic
 
 USER root
+RUN apt-get update
 RUN apt-get install -y fonts-noto
 
 USER pwuser


### PR DESCRIPTION
# Before
![Ubuntu 2021-12-04 11 01 54](https://user-images.githubusercontent.com/309271/144693055-958fcd09-7d14-40d1-8f7f-d629a2a682ce.png)

# After
![Ubuntu 2021-12-04 11 10 02](https://user-images.githubusercontent.com/309271/144693220-b40dfd5d-cd8c-4cf3-bf28-48ce06ea3307.png)
 