### PR TITLE
Always wrap long text in table display

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -120,7 +120,7 @@ export const handleRecordTable: Handler = ({ redash }) => {
       const dashes = '-'.repeat(friendly_name.length)
       cols[friendly_name] = `${friendly_name}\n${dashes}`
     }
-    const table = new Table([cols].concat(rows))
+    const table = new Table([cols].concat(rows), {break: true})
     let tableMessage = '```' + table.toString() + '```'
     tableMessage = tableMessage
       .split('\n')


### PR DESCRIPTION
## Description:

There are cases where long text breaks the table layout when displayed.
Below is a reproduction example:

**Original data**

| col1 | col2 | col3 |
|:---|:---|:---|
| 123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 | col12 | col13 |
| 1234567890123456789-1234567890123456789012345678901234567890123456789012345678901234567890 | col22 | col23 |
| 123456789-123456789-123456789-123456789-123456789-123456789-123456789-123456789-123456789 | col32 | col33 |

**Screenshot in Slack**

<img width="2490" height="740" alt="image" src="https://github.com/user-attachments/assets/cc1d051c-b608-4c6d-8f63-39cb50c80c07" />

This issue is due to the table-layout module's options configuration.
ref. https://github.com/75lb/table-layout/blob/v4.1.1/docs/API.md

Since no options are currently specified, maxWidth defaults to 80 characters.
Line breaks are only added when spaces or hyphens are present,
leading to the Slack output shown above.

This PR aims to improve table readability by adding the break option.

## Testing:

<img width="586" height="267" alt="image" src="https://github.com/user-attachments/assets/2aebc15c-bbf9-4fc7-a182-769f0dd86475" />

## Note:

We considered making the character limit per line configurable,
but Markdown formatting makes long lines difficult to read.
For this PR, we focused on the core implementation and opted against parameterizing this.